### PR TITLE
Improve progress message using new progress payload

### DIFF
--- a/exe/datatrue_client
+++ b/exe/datatrue_client
@@ -93,47 +93,6 @@ def datatrue_print(message)
   puts "datatrue_client: #{message}"
 end
 
-def get_state(details)
-  if details[:status] == 'completed'
-    if details[:progress]['tests'].all? { |result| ['success', 'validated'].include? result['state'] }
-      status = 'passed'
-    else
-      status = 'failed'
-    end
-  else
-    status = details[:status]
-  end
-end
-
-def build_progress_message(details)
-  state = get_state(details)
-  tests = details.dig(:progress, 'tests') || []
-  steps = tests.map { |test| test['steps'] }.compact.flatten
-  total_steps = details.dig(:progress, 'steps_total')
-  i = steps.index { |step| step['running'] }
-
-  if i
-    # format progress details if available
-    step = steps[i]
-    is_coverage_step = step['actions_total'] > 1
-    coverage_step_details = " (#{step['actions_completed']}/#{step['actions_total']} pages)"
-
-    message = %{
-      test_run_id=#{details[:options]['test_run_id']}
-      step=#{i + 1}#{is_coverage_step ? coverage_step_details : ''}
-      total_steps=#{total_steps}
-      result=#{state}
-    }
-  else
-    message = %{
-      test_run_id=#{details[:options]['test_run_id']}
-      result=#{state}
-    }
-  end
-
-  message.gsub(/\s+/, ' ').strip
-end
-
 begin
   options = parse(ARGV)
   command = ARGV.shift
@@ -171,11 +130,11 @@ begin
 
   if command == 'run'
     datatrue_print_progress = Proc.new do |progress, details|
-      datatrue_print(build_progress_message(details))
+      datatrue_print(DatatrueClient::TestRun.build_progress_message(details))
     end
 
     res = test_run.poll_progress(options.silent ? nil : datatrue_print_progress)
-    get_state(res) == 'passed' ? exit : exit(1)
+    DatatrueClient::TestRun.get_progress_status(res) == 'passed' ? exit : exit(1)
   else
     exit
   end

--- a/exe/datatrue_client
+++ b/exe/datatrue_client
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-#require "bundler/setup"
 require "optparse"
 require 'ostruct'
 require "datatrue_client"

--- a/exe/datatrue_client
+++ b/exe/datatrue_client
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+#require "bundler/setup"
 require "optparse"
 require 'ostruct'
 require "datatrue_client"
@@ -93,7 +94,7 @@ def datatrue_print(message)
   puts "datatrue_client: #{message}"
 end
 
-def process_result(details)
+def get_state(details)
   if details[:status] == 'completed'
     if details[:progress]['tests'].all? { |result| ['success', 'validated'].include? result['state'] }
       status = 'passed'
@@ -103,6 +104,35 @@ def process_result(details)
   else
     status = details[:status]
   end
+end
+
+def build_progress_message(details)
+  state = get_state(details)
+  tests = details.dig(:progress, 'tests') || []
+  steps = tests.map { |test| test['steps'] }.compact.flatten
+  total_steps = details.dig(:progress, 'steps_total')
+  i = steps.index { |step| step['running'] }
+
+  if i
+    # format progress details if available
+    step = steps[i]
+    is_coverage_step = step['actions_total'] > 1
+    coverage_step_details = " (#{step['actions_completed']}/#{step['actions_total']} pages)"
+
+    message = %{
+      test_run_id=#{details[:options]['test_run_id']}
+      step=#{i + 1}#{is_coverage_step ? coverage_step_details : ''}
+      total_steps=#{total_steps}
+      result=#{state}
+    }
+  else
+    message = %{
+      test_run_id=#{details[:options]['test_run_id']}
+      result=#{state}
+    }
+  end
+
+  message.gsub(/\s+/, ' ').strip
 end
 
 begin
@@ -124,15 +154,6 @@ begin
     exit
   end
 
-  datatrue_print_progress = Proc.new do |progress, details|
-    datatrue_print %{
-    test_run_id=#{details[:options]['test_run_id']}
-    step=#{details[:num]}
-    total_steps=#{details[:total]}
-    result=#{process_result(details)}
-    }.gsub(/\s+/, ' ').strip
-  end
-
   test_run = DatatrueClient::TestRun.new({
     host: options.host,
     scheme: options.scheme,
@@ -150,8 +171,12 @@ begin
   datatrue_print "job=#{test_run.job_id} created for test=\"#{test_run.title}\"" unless options.silent
 
   if command == 'run'
+    datatrue_print_progress = Proc.new do |progress, details|
+      datatrue_print(build_progress_message(details))
+    end
+
     res = test_run.poll_progress(options.silent ? nil : datatrue_print_progress)
-    process_result(res) == 'passed' ? exit : exit(1)
+    get_state(res) == 'passed' ? exit : exit(1)
   else
     exit
   end

--- a/lib/datatrue_client/test_run.rb
+++ b/lib/datatrue_client/test_run.rb
@@ -27,17 +27,17 @@ module DatatrueClient
         tests = details.dig(:progress, 'tests') || []
         steps = tests.map { |test| test['steps'] }.compact.flatten
         total_steps = details.dig(:progress, 'steps_total')
-        i = steps.index { |step| step['running'] }
+        current_step_index = steps.index { |step| step['running'] }
 
-        if i
+        if current_step_index
           # read step and crawled pages details
-          step = steps[i]
+          step = steps[current_step_index]
           is_coverage_step = step['actions_total'] > 1
           coverage_step_details = " (#{step['actions_completed']}/#{step['actions_total']} pages)"
 
           message = %{
             test_run_id=#{details[:options]['test_run_id']}
-            step=#{i + 1}#{is_coverage_step ? coverage_step_details : ''}
+            step=#{current_step_index + 1}#{is_coverage_step ? coverage_step_details : ''}
             total_steps=#{total_steps}
             result=#{status}
           }

--- a/spec/test_run_spec.rb
+++ b/spec/test_run_spec.rb
@@ -21,6 +21,45 @@ describe DatatrueClient::TestRun do
     })
   end
 
+  describe 'read progress data' do
+    before(:each) do
+      @progress_details = {
+        options: { 'test_run_id': 1 },
+        status: 'running',
+        num: 1,
+        total: 5,
+        progress: {
+          'steps_total' => 1,
+          'tests' => [
+            {
+              'id' => 1,
+              'name' => 'Test',
+              'actions_completed' => 1,
+              'actions_total' => 5,
+              'steps' => [
+                {
+                  'running' => true,
+                  'actions_completed' => 1,
+                  'actions_total' => 5
+                }
+              ]
+            }
+          ]
+        }
+      }
+    end
+
+    it '.get_progress_status' do
+      expect(DatatrueClient::TestRun.get_progress_status(@progress_details)).to eq('running')
+    end
+
+    it '.build_progress_message' do
+      expect(DatatrueClient::TestRun.build_progress_message(@progress_details)).to eq(
+        'test_run_id= step=1 (1/5 pages) total_steps=1 result=running'
+      )
+    end
+  end
+
   it 'sends a create test run request and sets job_id' do
     expect(@test_run.job_id).not_to be_nil
   end


### PR DESCRIPTION
Show number of crawled pages for coverage steps.

Dependency

https://github.com/Lens10/TagTrue/pull/1365

Example output
```
$ datatrue_client run 1 -a Sw16xGjfgJE2jkNXkGmaOg -t suite --timeout 600 --scheme http --host localhost:3030
datatrue_client: job=d63e2c37a5a83a05d9f16252cf03b3fa created for test="Welcome to DataTrue - here are some tests to get you started!"
datatrue_client: test_run_id=208 result=queued
datatrue_client: test_run_id=208 result=queued
datatrue_client: test_run_id=208 result=working
datatrue_client: test_run_id=208 result=working
datatrue_client: test_run_id=208 step=1 (0/5 pages) total_steps=7 result=working
datatrue_client: test_run_id=208 step=1 (0/5 pages) total_steps=7 result=working
datatrue_client: test_run_id=208 step=1 (0/5 pages) total_steps=7 result=working
datatrue_client: test_run_id=208 step=1 (1/5 pages) total_steps=7 result=working
datatrue_client: test_run_id=208 step=1 (1/5 pages) total_steps=7 result=working
datatrue_client: test_run_id=208 step=1 (1/5 pages) total_steps=7 result=working
datatrue_client: test_run_id=208 step=1 (2/5 pages) total_steps=7 result=working
datatrue_client: test_run_id=208 step=1 (2/5 pages) total_steps=7 result=working
datatrue_client: test_run_id=208 step=1 (3/5 pages) total_steps=7 result=working
datatrue_client: test_run_id=208 step=1 (3/5 pages) total_steps=7 result=working
datatrue_client: test_run_id=208 step=1 (3/5 pages) total_steps=7 result=working
datatrue_client: test_run_id=208 step=1 (4/5 pages) total_steps=7 result=working
datatrue_client: test_run_id=208 step=1 (5/5 pages) total_steps=7 result=working
datatrue_client: test_run_id=208 step=2 total_steps=7 result=working
datatrue_client: test_run_id=208 step=2 total_steps=7 result=working
datatrue_client: test_run_id=208 step=2 total_steps=7 result=working
datatrue_client: test_run_id=208 step=2 total_steps=7 result=working
datatrue_client: test_run_id=208 step=2 total_steps=7 result=working
datatrue_client: test_run_id=208 step=2 total_steps=7 result=working
datatrue_client: test_run_id=208 step=2 total_steps=7 result=working
datatrue_client: test_run_id=208 step=3 total_steps=7 result=working
datatrue_client: test_run_id=208 step=3 total_steps=7 result=working
datatrue_client: test_run_id=208 step=4 total_steps=7 result=working
datatrue_client: test_run_id=208 step=4 total_steps=7 result=working
datatrue_client: test_run_id=208 step=4 total_steps=7 result=working
datatrue_client: test_run_id=208 step=5 total_steps=7 result=working
datatrue_client: test_run_id=208 step=5 total_steps=7 result=working
datatrue_client: test_run_id=208 step=6 total_steps=7 result=working
datatrue_client: test_run_id=208 step=6 total_steps=7 result=working
datatrue_client: test_run_id=208 step=7 total_steps=7 result=working
datatrue_client: test_run_id=208 step=7 total_steps=7 result=working
datatrue_client: test_run_id=208 result=working
datatrue_client: test_run_id=208 result=working
datatrue_client: test_run_id=208 result=working
datatrue_client: test_run_id=208 result=failed
```